### PR TITLE
[FIX] Reload certs after publishing for sale

### DIFF
--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -82,6 +82,24 @@ export class AppContainer extends React.Component<IAppContainerProps, {}> {
             );
         });
 
+        certificateContractEventHandler.onEvent('LogPublishForSale', async (event: any) => {
+            this.props.actions.certificateCreatedOrUpdated(
+                await new Certificate.Entity(
+                    event.returnValues._entityId,
+                    this.props.configuration
+                ).sync()
+            );
+        });
+
+        certificateContractEventHandler.onEvent('LogUnpublishForSale', async (event: any) => {
+            this.props.actions.certificateCreatedOrUpdated(
+                await new Certificate.Entity(
+                    event.returnValues._entityId,
+                    this.props.configuration
+                ).sync()
+            );
+        });
+
         const demandContractEventHandler: ContractEventHandler = new ContractEventHandler(
             conf.blockchainProperties.marketLogicInstance,
             currentBlockNumber

--- a/src/components/CertificateTable.tsx
+++ b/src/components/CertificateTable.tsx
@@ -103,6 +103,7 @@ export class CertificateTable extends React.Component<ICertificateTableProps, IC
         this.showCertCreated = this.showCertCreated.bind(this);
         this.showCertificateDetails = this.showCertificateDetails.bind(this);
         this.getTokenSymbol = this.getTokenSymbol.bind(this);
+        this.hidePublishForSaleModal = this.hidePublishForSaleModal.bind(this);
     }
 
     async componentDidMount() {
@@ -227,6 +228,13 @@ export class CertificateTable extends React.Component<ICertificateTableProps, IC
         this.setState({
             sellModalForCertificate: certificate,
             showSellModal: true
+        });
+    }
+
+    hidePublishForSaleModal() {
+        this.setState({
+            sellModalForCertificate: null,
+            showSellModal: false
         });
     }
 
@@ -553,6 +561,7 @@ export class CertificateTable extends React.Component<ICertificateTableProps, IC
                             : null
                     }
                     showModal={this.state.showSellModal}
+                    callback={this.hidePublishForSaleModal}
                 />
             </div>
         );

--- a/src/elements/Modal/PublishForSaleModal.tsx
+++ b/src/elements/Modal/PublishForSaleModal.tsx
@@ -20,6 +20,7 @@ interface IPublishForSaleModalProps {
     certificate: Certificate.Entity;
     producingAsset: ProducingAsset.Entity;
     showModal: boolean;
+    callback: () => void;
 }
 
 interface IPublishForSaleModalState {
@@ -37,12 +38,12 @@ class PublishForSaleModal extends React.Component<IPublishForSaleModalProps, IPu
     constructor(props, context) {
         super(props, context);
 
-        this.handleShow = this.handleShow.bind(this);
         this.handleClose = this.handleClose.bind(this);
         this.publishForSale = this.publishForSale.bind(this);
         this.validateInputs = this.validateInputs.bind(this);
         this.isFormValid = this.isFormValid.bind(this);
 
+        // console.log(props.showModal)
         this.state = {
             show: props.showModal,
             price: 1,
@@ -57,6 +58,7 @@ class PublishForSaleModal extends React.Component<IPublishForSaleModalProps, IPu
     }
 
     componentWillReceiveProps(newProps: IPublishForSaleModalProps) {
+        console.log('new props: showModal' + newProps.showModal);
         this.setState({
             show: newProps.showModal,
         });
@@ -103,6 +105,7 @@ class PublishForSaleModal extends React.Component<IPublishForSaleModalProps, IPu
             }
 
             showNotification(`Certificate ${certificate.id} has been published for sale.`, NotificationType.Success);
+            this.props.callback();
             this.handleClose();
         }
     }
@@ -153,10 +156,6 @@ class PublishForSaleModal extends React.Component<IPublishForSaleModalProps, IPu
 
     handleClose() {
         this.setState({ show: false });
-    }
-
-    handleShow() {
-        this.setState({ show: true });
     }
 
     render() {

--- a/src/elements/Modal/PublishForSaleModal.tsx
+++ b/src/elements/Modal/PublishForSaleModal.tsx
@@ -43,7 +43,6 @@ class PublishForSaleModal extends React.Component<IPublishForSaleModalProps, IPu
         this.validateInputs = this.validateInputs.bind(this);
         this.isFormValid = this.isFormValid.bind(this);
 
-        // console.log(props.showModal)
         this.state = {
             show: props.showModal,
             price: 1,

--- a/src/elements/Modal/PublishForSaleModal.tsx
+++ b/src/elements/Modal/PublishForSaleModal.tsx
@@ -57,7 +57,6 @@ class PublishForSaleModal extends React.Component<IPublishForSaleModalProps, IPu
     }
 
     componentWillReceiveProps(newProps: IPublishForSaleModalProps) {
-        console.log('new props: showModal' + newProps.showModal);
         this.setState({
             show: newProps.showModal,
         });


### PR DESCRIPTION
There was an issue where after posting a certificate for sale, the user would need to reload the page to see the changes. This PR fixes it by listening to `publishForSale` logs and refreshing the page automatically.